### PR TITLE
Support case sensitivity with CharRangeTerminal

### DIFF
--- a/Eto.Parse.Tests/Markdown/MarkdownTests.cs
+++ b/Eto.Parse.Tests/Markdown/MarkdownTests.cs
@@ -12,7 +12,7 @@ namespace Eto.Parse.Tests.Markdown
 	[TestFixture, Category("not-working")]
 	public class MarkdownTests
 	{
-        public static string AssemblyBasePath => Path.GetDirectoryName(new Uri(typeof(MarkdownTests).Assembly.CodeBase).LocalPath);
+        public static string AssemblyBasePath => Path.GetDirectoryName(typeof(MarkdownTests).Assembly.Location);
         public static string BasePath => Path.Combine(AssemblyBasePath, "Markdown", "tests");
 		MarkdownGrammar grammar;
 		MarkdownDeep.Markdown deep;

--- a/Eto.Parse.Tests/Parsers/CharRangeTests.cs
+++ b/Eto.Parse.Tests/Parsers/CharRangeTests.cs
@@ -4,8 +4,8 @@ using NUnit.Framework;
 namespace Eto.Parse.Tests.Parsers
 {
 	[TestFixture]
-	public class CharSetTests
-	{
+    public class CharRangeTests
+    {
 		[TestCase(true, false)]
 		[TestCase(false, false)]
 		[TestCase(null, false)]
@@ -13,8 +13,9 @@ namespace Eto.Parse.Tests.Parsers
 		[TestCase(false, true)]
 		public void CaseSensitiveShouldBeCorrect(bool? caseSensitive, bool inherit)
 		{
-			var parser = new CharSetTerminal();
-			parser.Characters = "abcdef".ToCharArray();
+			var parser = new CharRangeTerminal();
+			parser.Start = 'a';
+			parser.End = 'f';
 			var grammar = new Grammar { Inner = parser };
 			
 			if (inherit)
@@ -24,7 +25,7 @@ namespace Eto.Parse.Tests.Parsers
 
 			Assert.IsTrue(grammar.Match("a").Success, "1.1");
 			Assert.IsTrue(grammar.Match("b").Success, "1.2");
-			Assert.IsTrue(grammar.Match("c").Success, "1.3");
+			Assert.IsTrue(grammar.Match("f").Success, "1.3");
 			
 			if (caseSensitive != false)
 			{
@@ -38,10 +39,10 @@ namespace Eto.Parse.Tests.Parsers
 				Assert.IsTrue(grammar.Match("B").Success, "3.2");
 				Assert.IsTrue(grammar.Match("F").Success, "3.3");
 			}
-			
+
 			// out of range
 			Assert.IsFalse(grammar.Match("g").Success, "4.1");
 			Assert.IsFalse(grammar.Match("G").Success, "4.2");
 		}
-	}
+    }
 }

--- a/Eto.Parse/Parsers/CharRangeTerminal.cs
+++ b/Eto.Parse/Parsers/CharRangeTerminal.cs
@@ -8,7 +8,7 @@ namespace Eto.Parse.Parsers
 		public char Start { get; set; }
 
 		public char End { get; set; }
-
+		
 		protected CharRangeTerminal(CharRangeTerminal other, ParserCloneArgs args)
 			: base(other, args)
 		{
@@ -28,6 +28,9 @@ namespace Eto.Parse.Parsers
 
 		protected override bool Test(char ch)
 		{
+			if (!TestCaseSensitive)
+				ch = char.ToLowerInvariant(ch);
+				
 			return ch >= Start && ch <= End;
 		}
 
@@ -40,5 +43,16 @@ namespace Eto.Parse.Parsers
 		{
 			return new CharRangeTerminal(this, args);
 		}
+
+		protected override void InnerInitialize(ParserInitializeArgs args)
+		{
+			base.InnerInitialize(args);
+			if (!TestCaseSensitive)
+			{
+				Start = char.ToLowerInvariant(Start);
+				End = char.ToLowerInvariant(End);
+			}
+		}
+
 	}
 }


### PR DESCRIPTION
For #49

This makes it easier to use a character range when not being case sensitive.